### PR TITLE
fix hourly cron scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ sometimes the `sbot` or `healer` containers will stop running (despite `--restar
 for this sitaution, we will setup two cron job scripts:
 
 ```shell
-echo "docker start sbot" | tee /etc/cron.hourly/sbot && chmod +x /etc/cron.hourly/sbot
-echo "docker start healer" | tee /etc/cron.hourly/healer && chmod +x /etc/cron.hourly/healer
+printf '#!/bin/sh\n\ndocker start sbot\n' | tee /etc/cron.hourly/sbot && chmod +x /etc/cron.hourly/sbot
+printf '#!/bin/sh\n\ndocker start healer\n' | tee /etc/cron.hourly/healer && chmod +x /etc/cron.hourly/healer
 ```
 
 because `docker start <service>` is [idempotent](https://en.wikipedia.org/wiki/Idempotent), it will not change anything if the service is already running, but if the service is not running it will start it.

--- a/install.sh
+++ b/install.sh
@@ -70,5 +70,5 @@ docker run -d --name healer \
   ahdinosaur/healer
 
 # ensure containers are always running
-echo "docker start sbot" | tee /etc/cron.hourly/sbot && chmod +x /etc/cron.hourly/sbot
-echo "docker start healer" | tee /etc/cron.hourly/healer && chmod +x /etc/cron.hourly/healer
+printf '#!/bin/sh\n\ndocker start sbot\n' | tee /etc/cron.hourly/sbot && chmod +x /etc/cron.hourly/sbot
+printf '#!/bin/sh\n\ndocker start healer\n' | tee /etc/cron.hourly/healer && chmod +x /etc/cron.hourly/healer


### PR DESCRIPTION
https://github.com/ahdinosaur/ssb-pub/issues/12#issuecomment-431627368

> gosh i'm silly, it wasn't working and is a real simple fix to get it to work.
>
> first i checked the cron service logs:
>
> ```shell
> journalctl -u cron.service
> ```
>
> the cron.hourly scripts is clearly running, a bunch of junk like:
>
> ```
> Oct 19 06:17:01 ssb-pub CRON[15809]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)
> Oct 19 06:17:01 ssb-pub CRON[15808]: (CRON) info (No MTA installed, discarding output)
> ```
>
> i find a relevant stackoverflow post: https://stackoverflow.com/questions/14647447/cronjob-cron-daily-does-not-run-debian
>
> says to try running the command the cron service is running:
>
> ```
> run-parts --report /etc/cron.hourly
> ```
>
> and yep, it's broken:
>
> ```
> root@ssb-pub:~# run-parts --report /etc/cron.hourly
> /etc/cron.hourly/healer:
> run-parts: failed to exec /etc/cron.hourly/healer: Exec format error
> run-parts: /etc/cron.hourly/healer exited with return code 1
> /etc/cron.hourly/sbot:
> run-parts: failed to exec /etc/cron.hourly/sbot: Exec format error
> run-parts: /etc/cron.hourly/sbot exited with return code 1
> ```
>
> i guess that it's because the scripts don't have a shebang, so i give each a wee `#!/bin/sh`, and boom:
>
> ```
> root@ssb-pub:~# run-parts --report /etc/cron.hourly
> /etc/cron.hourly/healer:
> healer
> /etc/cron.hourly/sbot:
> sbot
> ```

chur @mixmix