### PR TITLE
Use tini as pid1 in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:8
 MAINTAINER Michael Williams <michael.williams@enspiral.com>
 
 USER root
+ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini
+RUN chmod +x /tini
 RUN mkdir /home/node/.npm-global ; \
     chown -R node:node /home/node/
 ENV PATH=/home/node/.npm-global/bin:$PATH
@@ -17,5 +19,5 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=10 \
   CMD sbot whoami || exit 1
 ENV HEALING_ACTION RESTART
 
-ENTRYPOINT [ "sbot" ]
+ENTRYPOINT [ "/tini", "--", "sbot" ]
 CMD [ "server" ]


### PR DESCRIPTION
Because `sbot server` does not install signal handlers and is run as PID 1 the SIGINT and SIGTERM signals do not terminate the process. This means for example that `docker stop` takes a long time since it waits for SIGTERM to have an effect and then sends SIGKILL. [`tini`][1] solves this problem.

[1]: https://github.com/krallin/tini#readme